### PR TITLE
Version 1.2

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,35 @@
+# Guia de Atualização para v1.2
+
+## Requisitos
+
+- PHP versão mínima atualizada para 8.0.
+- Laravel versão mínima atualizada para 8.0.
+
+## Mudanças Principais nas classes da biblioteca
+
+- Constantes para controle das chaves de retorno na função `Kascat\EasyModule\Core\Service::buildReturn`
+  ```
+  Kascat\EasyModule\Core\Service::RESPONSE; // 'response'
+  Kascat\EasyModule\Core\Service::HTTP_STATUS; // 'status'
+  ```
+- Constantes para chaves de paginação e carregamento de relacionamento
+  ```
+  Kascat\EasyModule\Core\Service::WITH_RELATIONSHIP; // 'with'
+  Kascat\EasyModule\Core\Service::PER_PAGE; // 'perPage'
+  ```
+
+
+## Mudanças Principais nos arquivos gerados no módulo
+
+- Adição de return types em funções e tipagem de parâmetros
+- Remoção de DocBlocks, deixando os arquivos mais limpos
+- Definição da propriedade privada de acesso ao `Service` do módulo diretamente no construct da controller
+- Novo nome para função de filtro da listagem no Repository: `defautFiltersQuery`
+- Exemplo comentado de filtro na função `defautFiltersQuery`, facilitando adição de próximos
+- Uso das novas contantes de paginação e carregamento de relacionamento no Service
+- Definição de Constantes das propriedades da Model
+  - A ideia é fazer o uso das contantes ao invez de usar diretamente fixo no código as propriedades da Model
+  - Exemplo: `$objeto->update([ExemploModel::NOME_PROPRIEDADE => 'valor'])`
+- Mapeamento das propriedades no DocBlock da Model, auxiliando a leitura das propriedades pelas IDEs
+- Alteração da definição de `protected $fillable` na Model para `protected $guarded`
+- Exemplo de validações no Request, com uso de constante da Model na definição da chave do array

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/kascat",
     "type": "library",
     "license": "MIT",
-    "version": "1.1",
+    "version": "1.2",
     "authors": [
         {
             "name": "Fabio Dukievicz",
@@ -18,8 +18,8 @@
         }
     },
     "require": {
-        "php": "^7.1 || ^8.0",
-        "laravel/framework": ">=6.0"
+        "php": "^8.0",
+        "laravel/framework": ">=8.0"
     },
     "minimum-stability": "dev"
 }

--- a/src/Core/Request.php
+++ b/src/Core/Request.php
@@ -15,7 +15,6 @@ namespace Kascat\EasyModule\Core;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Http\Response;
 use Illuminate\Support\Str;
 
 /**
@@ -65,7 +64,7 @@ class Request extends FormRequest
     protected function failedValidation(Validator $validator)
     {
         throw new HttpResponseException(
-            response()->json($validator->errors(), Response::HTTP_UNPROCESSABLE_ENTITY)
+            response()->json($validator->errors(), 422)
         );
     }
 }

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -21,13 +21,13 @@ use Illuminate\Support\Str;
 trait Response
 {
     /**
-     * @param $data
+     * @param mixed $data
      * @param int $statusCode
      * @param array $headers
      * @param int $options
      * @return mixed
      */
-    public function response($data = [], int $statusCode = \Illuminate\Http\Response::HTTP_OK, array $headers = [], $options = 0)
+    public function response(mixed $data = [], int $statusCode = 200, array $headers = [], $options = 0)
     {
         $method = "responseTo" . Str::ucfirst(request()->route()->getActionMethod());
 

--- a/src/Core/Service.php
+++ b/src/Core/Service.php
@@ -12,9 +12,6 @@
 
 namespace Kascat\EasyModule\Core;
 
-use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Http\Response;
-
 /**
  * Class Service
  * @package Kascat\EasyModule\Core
@@ -23,16 +20,22 @@ class Service
 {
     use Utils;
 
+    const RESPONSE = 'response';
+    const HTTP_STATUS = 'status';
+
+    const WITH_RELATIONSHIP = 'with';
+    const PER_PAGE = 'perPage';
+
     /**
-     * @param $response
-     * @param int $statusCode
+     * @param mixed $response
+     * @param int $httpStatus
      * @return array
      */
-    protected static function buildReturn($response = [], int $statusCode = Response::HTTP_OK): array
+    protected static function buildReturn(mixed $response = [], int $httpStatus = 200): array
     {
         return [
-            'response' => $response,
-            'status'   => $statusCode
+            self::RESPONSE => $response,
+            self::HTTP_STATUS => $httpStatus,
         ];
     }
 }

--- a/src/stubs/api.stub
+++ b/src/stubs/api.stub
@@ -1,9 +1,16 @@
 <?php
 
+/**
+ * Easy Module library
+ * Packagist: https://packagist.org/packages/kascat/easy-module
+ * GitHub: https://github.com/kascat/easy-module
+ */
+
 use Illuminate\Support\Facades\Route;
+use {{modelNamePlural}}\{{modelName}}Controller;
 
 Route::group([
     // 'middleware' => ['auth:sanctum']
 ], function () {
-    Route::apiResource('{{modelNamePluralLowerCase}}', {{modelNamePlural}}\{{modelName}}Controller::class);
+    Route::apiResource('{{modelNamePluralLowerCase}}', {{modelName}}Controller::class);
 });

--- a/src/stubs/console.stub
+++ b/src/stubs/console.stub
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Easy Module library
+ * Packagist: https://packagist.org/packages/kascat/easy-module
+ * GitHub: https://github.com/kascat/easy-module
+ */
+
 use Illuminate\Support\Facades\Artisan;
 
 /*

--- a/src/stubs/controller.stub
+++ b/src/stubs/controller.stub
@@ -1,39 +1,21 @@
 <?php
 
-/**
- * Easy Module library
- * Packagist: https://packagist.org/packages/kascat/easy-module
- * GitHub: https://github.com/kascat/easy-module
- */
-
 namespace {{modelNamePlural}};
 
 use App\Http\Controllers\Controller;
 
 /**
  * Class {{modelName}}Controller
- * @package {{modelNamePlural}}
  */
 class {{modelName}}Controller extends Controller
 {
     use {{modelName}}Response;
 
-    /** @var {{modelName}}Service */
-    private {{modelName}}Service ${{modelNameSingularLowerCase}}Service;
-
-    /**
-     * {{modelName}}Controller constructor.
-     * @param {{modelName}}Service ${{modelNameSingularLowerCase}}Service
-     */
-    public function __construct({{modelName}}Service ${{modelNameSingularLowerCase}}Service)
+    public function __construct(private readonly {{modelName}}Service ${{modelNameSingularLowerCase}}Service)
     {
-        $this->{{modelNameSingularLowerCase}}Service = ${{modelNameSingularLowerCase}}Service;
+        //
     }
 
-    /**
-     * @param {{modelName}}Request $request
-     * @return mixed
-     */
     public function index({{modelName}}Request $request): mixed
     {
         $result = $this->{{modelNameSingularLowerCase}}Service->index($request->validated());
@@ -41,10 +23,6 @@ class {{modelName}}Controller extends Controller
         return $this->response($result['response'], $result['status']);
     }
 
-    /**
-     * @param {{modelName}}Request $request
-     * @return mixed
-     */
     public function store({{modelName}}Request $request): mixed
     {
         $result = $this->{{modelNameSingularLowerCase}}Service->store($request->validated());
@@ -52,10 +30,6 @@ class {{modelName}}Controller extends Controller
         return $this->response($result['response'], $result['status']);
     }
 
-    /**
-     * @param {{modelName}} ${{modelNameSingularLowerCase}}
-     * @return mixed
-     */
     public function show({{modelName}} ${{modelNameSingularLowerCase}}): mixed
     {
         $result = $this->{{modelNameSingularLowerCase}}Service->show(${{modelNameSingularLowerCase}});
@@ -63,11 +37,6 @@ class {{modelName}}Controller extends Controller
         return $this->response($result['response'], $result['status']);
     }
 
-    /**
-     * @param {{modelName}}Request $request
-     * @param {{modelName}} ${{modelNameSingularLowerCase}}
-     * @return mixed
-     */
     public function update({{modelName}}Request $request, {{modelName}} ${{modelNameSingularLowerCase}}): mixed
     {
         $result = $this->{{modelNameSingularLowerCase}}Service->update(${{modelNameSingularLowerCase}}, $request->validated());
@@ -75,10 +44,6 @@ class {{modelName}}Controller extends Controller
         return $this->response($result['response'], $result['status']);
     }
 
-    /**
-     * @param {{modelName}} ${{modelNameSingularLowerCase}}
-     * @return mixed
-     */
     public function destroy({{modelName}} ${{modelNameSingularLowerCase}}): mixed
     {
         $result = $this->{{modelNameSingularLowerCase}}Service->destroy(${{modelNameSingularLowerCase}});

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -1,34 +1,30 @@
 <?php
 
-/**
- * Easy Module library
- * Packagist: https://packagist.org/packages/kascat/easy-module
- * GitHub: https://github.com/kascat/easy-module
- */
-
 namespace {{modelNamePlural}};
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class {{modelName}}
- * @package {{modelNamePlural}}
+ * @property int         $id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  */
 class {{modelName}} extends Model
 {
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = '{{modelNamePluralLowerCase}}';
+    const ID = 'id';
+    // Enter other property constants here, example: const NAME = 'name';
+    const CREATED_AT = 'created_at';
+    const UPDATED_AT = 'updated_at';
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        //
+    const TABLE = '{{modelNamePluralLowerCase}}';
+
+    protected $table = self::TABLE;
+
+    protected $guarded = [
+        self::ID,
+        self::CREATED_AT,
+        self::UPDATED_AT,
     ];
 }

--- a/src/stubs/repository.stub
+++ b/src/stubs/repository.stub
@@ -1,27 +1,20 @@
 <?php
 
-/**
- * Easy Module library
- * Packagist: https://packagist.org/packages/kascat/easy-module
- * GitHub: https://github.com/kascat/easy-module
- */
-
 namespace {{modelNamePlural}};
+
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class {{modelName}}Repository
- * @package {{modelNamePlural}}
- *
- * Build module query here.
+ * Build commom module queries here
  */
 class {{modelName}}Repository
 {
-    /**
-     * @param $filters
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public static function index($filters)
+    public static function defautFiltersQuery(mixed $filters = []): Builder
     {
         return {{modelName}}::query();
+        //    ->when($filters[{{modelName}}::NAME] ?? null, function (Builder $query, $value) {
+        //        $query->where({{modelName}}::NAME, 'like', "%$value%");
+        //    });
     }
 }

--- a/src/stubs/request.stub
+++ b/src/stubs/request.stub
@@ -1,51 +1,35 @@
 <?php
 
-/**
- * Easy Module library
- * Packagist: https://packagist.org/packages/kascat/easy-module
- * GitHub: https://github.com/kascat/easy-module
- */
-
 namespace {{modelNamePlural}};
 
 use Kascat\EasyModule\Core\Request;
 
 /**
  * Class {{modelName}}Request
- * @package {{modelNamePlural}}
  */
 class {{modelName}}Request extends Request
 {
-    /**
-     * @return array
-     */
     public function validateToIndex(): array
     {
         return [
-            // Allowed properties to filter:
-            // 'name' => '',
+            // Allowed properties to filter, ex:
+            // {{modelName}}::NAME => 'string',
         ];
     }
 
-    /**
-     * @return array
-     */
     public function validateToStore(): array
     {
         return [
-            // Property rules to update ex:
-            // 'name' => 'required|string',
+            // Property rules to store, ex:
+            // {{modelName}}::NAME => 'required|string',
         ];
     }
 
-    /**
-     * @return array
-     */
     public function validateToUpdate(): array
     {
         return [
-            // Property rules to update ex:
-            // 'name' => 'string',
+            // Property rules to update, ex:
+            // {{modelName}}::NAME => 'string',
         ];
     }
 }

--- a/src/stubs/response.stub
+++ b/src/stubs/response.stub
@@ -1,31 +1,19 @@
 <?php
 
-/**
- * Easy Module library
- * Packagist: https://packagist.org/packages/kascat/easy-module
- * GitHub: https://github.com/kascat/easy-module
- */
-
 namespace {{modelNamePlural}};
 
+use Illuminate\Http\JsonResponse;
 use Kascat\EasyModule\Core\Response;
 
 /**
  * Response interceptor
- *
  * Trait {{modelName}}Response
- * @package {{modelNamePlural}}
  */
 trait {{modelName}}Response
 {
     use Response;
 
-    /**
-     * @param mixed $data
-     * @param int $statusCode
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function responseToIndex($data = [], int $statusCode = 200)
+    public function responseToIndex(mixed $data = [], int $statusCode = 200): JsonResponse
     {
         return response()->json($data, $statusCode);
     }

--- a/src/stubs/service.stub
+++ b/src/stubs/service.stub
@@ -1,65 +1,41 @@
 <?php
 
-/**
- * Easy Module library
- * Packagist: https://packagist.org/packages/kascat/easy-module
- * GitHub: https://github.com/kascat/easy-module
- */
-
 namespace {{modelNamePlural}};
 
 use Kascat\EasyModule\Core\Service;
 
 /**
  * Class {{modelName}}Service
- * @package {{modelNamePlural}}
  */
 class {{modelName}}Service extends Service
 {
-    /**
-     * @param array $filters
-     * @return array
-     */
     public function index(array $filters): array
     {
-        ${{modelNamePluralLowerCase}}Query = {{modelName}}Repository::index($filters);
+        ${{modelNamePluralLowerCase}}Query = {{modelName}}Repository::defautFiltersQuery($filters);
 
         return self::buildReturn(
             ${{modelNamePluralLowerCase}}Query
-                ->with(\request()->with ?? [])
-                ->paginate(\request()->perPage)
+                ->with(\request(self::WITH_RELATIONSHIP) ?? [])
+                ->paginate(\request(self::PER_PAGE))
         );
     }
 
-    /**
-     * @param {{modelName}} ${{modelNameSingularLowerCase}}
-     * @return array
-     */
     public function show({{modelName}} ${{modelNameSingularLowerCase}}): array
     {
         return self::buildReturn(
             ${{modelNameSingularLowerCase}}
-                ->load(\request('with') ?? [])
+                ->load(\request(self::WITH_RELATIONSHIP) ?? [])
                 ->toArray()
         );
     }
 
-    /**
-     * @param array $data
-     * @return array
-     */
     public function store(array $data): array
     {
-        ${{modelNameSingularLowerCase}} = {{modelName}}::create($data);
+        ${{modelNameSingularLowerCase}} = {{modelName}}::query()->create($data);
 
         return self::buildReturn(${{modelNameSingularLowerCase}});
     }
 
-    /**
-     * @param {{modelName}} ${{modelNameSingularLowerCase}}
-     * @param array $data
-     * @return array
-     */
     public function update({{modelName}} ${{modelNameSingularLowerCase}}, array $data): array
     {
         ${{modelNameSingularLowerCase}}->update($data);
@@ -67,10 +43,6 @@ class {{modelName}}Service extends Service
         return self::buildReturn(${{modelNameSingularLowerCase}});
     }
 
-    /**
-     * @param {{modelName}} ${{modelNameSingularLowerCase}}
-     * @return array
-     */
     public function destroy({{modelName}} ${{modelNameSingularLowerCase}}): array
     {
         ${{modelNameSingularLowerCase}}->delete();

--- a/src/stubs/web.stub
+++ b/src/stubs/web.stub
@@ -1,9 +1,16 @@
 <?php
 
+/**
+ * Easy Module library
+ * Packagist: https://packagist.org/packages/kascat/easy-module
+ * GitHub: https://github.com/kascat/easy-module
+ */
+
 use Illuminate\Support\Facades\Route;
+use {{modelNamePlural}}\{{modelName}}Controller;
 
 Route::group([
     // 'middleware' => ['auth:sanctum']
 ], function () {
-    Route::resource('{{modelNamePluralLowerCase}}', {{modelNamePlural}}\{{modelName}}Controller::class);
+    Route::resource('{{modelNamePluralLowerCase}}', {{modelName}}Controller::class);
 });


### PR DESCRIPTION
# Versão 1.2

## Requisitos

- PHP versão mínima atualizada para 8.0.
- Laravel versão mínima atualizada para 8.0.

## Mudanças Principais nas classes da biblioteca

- Constantes para controle das chaves de retorno na função `Kascat\EasyModule\Core\Service::buildReturn`
  ```
  Kascat\EasyModule\Core\Service::RESPONSE; // 'response'
  Kascat\EasyModule\Core\Service::HTTP_STATUS; // 'status'
  ```
- Constantes para chaves de paginação e carregamento de relacionamento
  ```
  Kascat\EasyModule\Core\Service::WITH_RELATIONSHIP; // 'with'
  Kascat\EasyModule\Core\Service::PER_PAGE; // 'perPage'
  ```


## Mudanças Principais nos arquivos gerados no módulo

- Adição de return types em funções e tipagem de parâmetros
- Remoção de DocBlocks, deixando os arquivos mais limpos
- Definição da propriedade privada de acesso ao `Service` do módulo diretamente no construct da controller
- Novo nome para função de filtro da listagem no Repository: `defautFiltersQuery`
- Exemplo comentado de filtro na função `defautFiltersQuery`, facilitando adição de próximos
- Uso das novas contantes de paginação e carregamento de relacionamento no Service
- Definição de Constantes das propriedades da Model
  - A ideia é fazer o uso das contantes ao invez de usar diretamente fixo no código as propriedades da Model
  - Exemplo: `$objeto->update([ExemploModel::NOME_PROPRIEDADE => 'valor'])`
- Mapeamento das propriedades no DocBlock da Model, auxiliando a leitura das propriedades pelas IDEs
- Alteração da definição de `protected $fillable` na Model para `protected $guarded`
- Exemplo de validações no Request, com uso de constante da Model na definição da chave do array
